### PR TITLE
Added fullscreen hotkey

### DIFF
--- a/lib/Artplayer.js
+++ b/lib/Artplayer.js
@@ -138,6 +138,12 @@ export default function Player({
         },
       ].filter(Boolean),
     });
+    
+    art.events.proxy(document,"keydown", event => {
+      if (event.key === 'f' || event.key === 'F') {
+      art.fullscreen = !art.fullscreen;
+      }
+    });
 
     if (getInstance && typeof getInstance === "function") {
       getInstance(art);


### PR DESCRIPTION
Press the F key to fullscreen. This works without focusing on the player lol, the right way should be this 
`art.on('ready', () => {
    art.hotkey.add(70, ()=>art.fullscreen = !art.fullscreen);
});`